### PR TITLE
Update Contact for Seniors

### DIFF
--- a/app/src/main/java/org/ramonaza/officialramonapp/datafiles/ContactInfoWrapper.java
+++ b/app/src/main/java/org/ramonaza/officialramonapp/datafiles/ContactInfoWrapper.java
@@ -78,7 +78,11 @@ public class ContactInfoWrapper{
         
         if (currentMonth > 6)   currentYear++;                  // the school year passes through the real year, this should fix that
         
-        return gradYearInt - currentYear;
+        int dif = gradYearInt - currentYear;
+        if (dif == -1 && currentMonth <= 8)                     // if the person is a senior in summer, say he's still a senior
+            dif++;
+        
+        return dif;
     }
 
 


### PR DESCRIPTION
The default setting is that, during the summer, your grade is equal to the one you will be next year.
However, I would not want to call seniors college freshmen before their life ceremonies, so this adds and exception for seniors
