### PR TITLE
Never remove coinhabitants from car when dismissing preexisting assignments

### DIFF
--- a/app/src/main/java/org/ramonaza/officialramonapp/people/rides/backend/RidesOptimizer.java
+++ b/app/src/main/java/org/ramonaza/officialramonapp/people/rides/backend/RidesOptimizer.java
@@ -88,13 +88,11 @@ public class RidesOptimizer {
         if (algorithm < 0 || driversToOptimize.isEmpty()) return;
         if(!retainPreexisting){
             for(DriverInfoWrapper driver:driversToOptimize){
-                for(ContactInfoWrapper aleph : driver.getAlephsInCar()){
-                    alephsToOptimize.add(aleph);
-                }
-                int dSize=driver.getAlephsInCar().size();
-                while(dSize>0){
-                    driver.removeAlephFromCar(driver.getAlephsInCar().get(dSize-1));
-                    dSize=driver.getAlephsInCar().size();
+                for(ContactInfoWrapper aleph : new ArrayList<ContactInfoWrapper>(driver.getAlephsInCar())){
+                    if (distBetweenHouses(driver, aleph) != 0) {
+                        driver.removeAlephFromCar(aleph);
+                        alephsToOptimize.add(aleph);
+                    }
                 }
             }
         }


### PR DESCRIPTION
If a passenger in a driver's car lives in the same house as that driver, they will never be removed by the !retainPreexisting clause. I meant to add a button to also clear the cars without having to run "None" algorithm, but I'm too tired. With this change, the naiveHungarian algorithm should work much better. Will soon add quantitative measure of how good a given rides list is.
